### PR TITLE
feat: adds saleor storefront and dashboard services

### DIFF
--- a/tutorsaleor/patches/caddyfile
+++ b/tutorsaleor/patches/caddyfile
@@ -1,0 +1,12 @@
+{% if RUN_SALEOR_DASHBOARD %}
+# Saleor Dashboard
+{{ SALEOR_DASHBOARD_HOST }}{$default_site_port} {
+    import proxy "saleor-dashboard:{{SALEOR_DASHBOARD_PORT}}"
+}
+{% endif %}
+{% if RUN_SALEOR_STOREFRONT %}
+# Saleor Storefront
+{{ SALEOR_STOREFRONT_HOST }}{$default_site_port} {
+    import proxy "saleor-storefront:{{SALEOR_STOREFRONT_PORT}}"
+}
+{% endif %}

--- a/tutorsaleor/patches/local-docker-compose-services
+++ b/tutorsaleor/patches/local-docker-compose-services
@@ -1,0 +1,23 @@
+{% if RUN_SALEOR_DASHBOARD %}
+saleor-dashboard:
+    image: {{ SALEOR_DASHBOARD_IMAGE }}
+    environment:
+      API_URL: "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ SALEOR_CORE_HOST }}:{{ SALEOR_CORE_PORT }}/graphql/"
+      APP_MOUNT_URI: "/dashboard/"
+    ports:
+      - "{{ SALEOR_DASHBOARD_PORT }}:80"
+    stdin_open: true
+    tty: true
+    restart: unless-stopped
+{% endif %}
+
+{% if RUN_SALEOR_STOREFRONT %}
+saleor-storefront:
+    image: {{ SALEOR_STOREFRONT_IMAGE }}
+    ports:
+      - "{{ SALEOR_STOREFRONT_PORT }}:3000"
+    command: ["pnpm", "start"]
+    stdin_open: true
+    tty: true
+    restart: unless-stopped
+{% endif %}

--- a/tutorsaleor/plugin.py
+++ b/tutorsaleor/plugin.py
@@ -17,6 +17,18 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         # Each new setting is a pair: (setting_name, default_value).
         # Prefix your setting names with 'SALEOR_'.
         ("SALEOR_VERSION", __version__),
+        ("RUN_SALEOR_DASHBOARD", True),
+        ("RUN_SALEOR_STOREFRONT", True),
+        ("SALEOR_DASHBOARD_IMAGE", "ghcr.io/saleor/saleor-dashboard:3.20.34"),
+        ("SALEOR_STOREFRONT_IMAGE", "edunext/saleor-storefront:3.20.34"),
+        ("SALEOR_CORE_HOST", "saleor-api.{{ LMS_HOST }}"),
+        ("SALEOR_DASHBOARD_HOST", "saleor-dashboard.{{ LMS_HOST }}"),
+        ("SALEOR_STOREFRONT_HOST", "saleor-storefront.{{ LMS_HOST }}"),
+        ("SALEOR_CORE_PORT", "18000"),
+        ("SALEOR_DASHBOARD_PORT", "18010"),
+        ("SALEOR_STOREFRONT_PORT", "18020"),
+        ("SALEOR_STOREFRONT_BRANCH", "main"),
+        ("SALEOR_STOREFRONT_REPOSITORY", "https://github.com/saleor/storefront"),
     ]
 )
 
@@ -83,12 +95,12 @@ hooks.Filters.IMAGES_BUILD.add_items(
         # To build `myimage` with `tutor images build myimage`,
         # you would add a Dockerfile to templates/saleor/build/myimage,
         # and then write:
-        ### (
-        ###     "myimage",
-        ###     ("plugins", "saleor", "build", "myimage"),
-        ###     "docker.io/myimage:{{ SALEOR_VERSION }}",
-        ###     (),
-        ### ),
+        (
+            "storefront",
+            ("plugins", "saleor", "build", "storefront"),
+            "{{ SALEOR_STOREFRONT_IMAGE }}",
+            (),
+        ),
     ]
 )
 

--- a/tutorsaleor/templates/saleor/build/storefront/Dockerfile
+++ b/tutorsaleor/templates/saleor/build/storefront/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:18-alpine
+
+RUN apk add --no-cache git
+
+RUN npm install -g pnpm
+
+WORKDIR /app
+
+RUN git clone -b {{ SALEOR_STOREFRONT_BRANCH }} {{ SALEOR_STOREFRONT_REPOSITORY }} storefront
+
+WORKDIR /app/storefront
+
+# This requires the saleor core service to load the graphql schema
+# ENV NEXT_PUBLIC_SALEOR_API_URL="{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ SALEOR_CORE_HOST }}:{{ SALEOR_CORE_PORT }}/graphql/"
+# ENV NEXT_PUBLIC_STOREFRONT_URL="{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ SALEOR_STOREFRONT_HOST }}:{{ SALEOR_STOREFRONT_PORT }}/"
+
+# Use default variables
+RUN cp .env.example .env
+
+RUN pnpm install
+
+RUN pnpm run build
+
+EXPOSE 3000


### PR DESCRIPTION
## Description
This adds the basic version of dashboard and storefront services


## How to test
1. Checkout this branch
2. Save the configuration `tutor config save`
3. Create the storefront image `tutor images build storefront`
4. Initialize your environment `tutor local start` or `tutor dev start -d`
5.  Check the services `http://saleor-storefront.local.overhang.io:18020/`  and `http://saleor-dashboard.local.overhang.io:18010/dashboard`

## Result

![image](https://github.com/user-attachments/assets/4195163a-dca0-4445-a6ae-ff5d5d47f4d8)

![image](https://github.com/user-attachments/assets/9a84c64e-223a-48d0-b929-e21ed20b7198)

